### PR TITLE
Change color order for LED

### DIFF
--- a/esp32-s3-zero.yaml
+++ b/esp32-s3-zero.yaml
@@ -67,7 +67,7 @@ button:
 
 light:
   - platform: esp32_rmt_led_strip
-    rgb_order: GRB
+    rgb_order: RGB
     pin: GPIO21
     num_leds: 1
     rmt_channel: 0


### PR DESCRIPTION
This is the correct color order for the on-board LED. At least, on the WS-S3-Zero I purchased in mid 2025. I guess it's possible they swapped, but...